### PR TITLE
fix: update @minecraft/server version to 2.4.0-beta

### DIFF
--- a/bp/manifest.json
+++ b/bp/manifest.json
@@ -29,7 +29,7 @@
     "dependencies": [
         {
             "module_name": "@minecraft/server",
-            "version": "2.3.0-beta"
+            "version": "2.4.0-beta"
         },
         {
             "module_name": "@minecraft/server-ui",


### PR DESCRIPTION
This pull request updates the dependency version for `@minecraft/server` in the `bp/manifest.json` file to ensure compatibility with the latest features and bug fixes.

* Dependency update:
  * Upgraded `@minecraft/server` from version `2.3.0-beta` to `2.4.0-beta` in `bp/manifest.json`.